### PR TITLE
fix windows

### DIFF
--- a/src/backends/win32/backend.zig
+++ b/src/backends/win32/backend.zig
@@ -216,6 +216,7 @@ pub fn Events(comptime T: type) type {
                         handler(&dc, data.userdata);
                     }
                 },
+                win32.WM_DESTROY => win32.PostQuitMessage(0),
                 else => {},
             }
             return win32.DefWindowProcA(hwnd, wm, wp, lp);


### PR DESCRIPTION
1. Don't build the broken examples by default (can still try to build/run them explicitly)
2. Properly detect the right directory separator (for windows use `'\'`) when converting example path to name
3. Use the `'\'` path separator on Windows
4. Handle the WM_DESTROY window message so the process exits when the user closes the window

With this I can now build/run 4 of the examples on my Windows 10 machine, `calculator`, `colors`, `demo` and `graph`.