### PR TITLE
Fix memory leak in calculator example

### DIFF
--- a/examples/calculator.zig
+++ b/examples/calculator.zig
@@ -75,6 +75,7 @@ pub fn compute(button: *zgt.Button_Impl) !void {
 
     const text = try std.fmt.allocPrintZ(allocator, "{d}", .{result});
     computationLabel.setText(text);
+    allocator.free(text);
 }
 
 pub fn main() !void {


### PR DESCRIPTION
Found this small memory leak in calculator example while casually playing.