### PR TITLE
Fix overflow in containers.zig

### DIFF
--- a/src/containers.zig
+++ b/src/containers.zig
@@ -32,11 +32,6 @@ fn getExpandedCount(widgets: []Widget) u32 {
     return expandedCount;
 }
 
-// Safely subtract b from a
-inline fn subtract(a: u32, b: u32) u32 {
-    return if (a < b) 0 else a - b;
-}
-
 const ColumnRowConfig = struct {
     spacing: u32 = 0,
 };

--- a/src/containers.zig
+++ b/src/containers.zig
@@ -69,7 +69,7 @@ pub fn ColumnLayout(peer: Callbacks, widgets: []Widget) void {
         if (widget.peer) |widgetPeer| {
             const available = Size{
                 .width = @intCast(u32, peer.getSize(peer.userdata).width),
-                .height = if (widget.container_expanded) childHeight else subtract(@intCast(u32, peer.getSize(peer.userdata).height), @floatToInt(u32, childY)),
+(@intCast(u32, peer.getSize(peer.userdata).height) -| @floatToInt(u32, childY))
             };
             const preferred = widget.getPreferredSize(available);
             const size = blk: {

--- a/src/containers.zig
+++ b/src/containers.zig
@@ -32,6 +32,11 @@ fn getExpandedCount(widgets: []Widget) u32 {
     return expandedCount;
 }
 
+// Safely subtract b from a
+inline fn subtract(a: u32, b: u32) u32 {
+    return if (a < b) 0 else a - b;
+}
+
 const ColumnRowConfig = struct {
     spacing: u32 = 0,
 };
@@ -56,13 +61,15 @@ pub fn ColumnLayout(peer: Callbacks, widgets: []Widget) void {
         }
     }
 
+
+
     var childY: f32 = 0.0;
     for (widgets) |widget, i| {
         const isLastWidget = i == widgets.len - 1;
         if (widget.peer) |widgetPeer| {
             const available = Size{
                 .width = @intCast(u32, peer.getSize(peer.userdata).width),
-                .height = if (widget.container_expanded) childHeight else (@intCast(u32, peer.getSize(peer.userdata).height) - @floatToInt(u32, childY)),
+                .height = if (widget.container_expanded) childHeight else subtract(@intCast(u32, peer.getSize(peer.userdata).height), @floatToInt(u32, childY)),
             };
             const preferred = widget.getPreferredSize(available);
             const size = blk: {


### PR DESCRIPTION
Thanks for making this project! 

With the  tab layout I sometimes get an integer overflow.

```zig
  var window = try zgt.Window.init();
    var zero_btn = zgt.Button(.{ .label = "Zero", .onclick = testClicked });
    var value_lbl = zgt.Label(.{ .text="Text"});

    try window.set(
        zgt.Tabs(.{
            zgt.Tab(.{ .label = "Scale" }, zgt.Column(.{}, .{
                &value_lbl,
                &zero_btn,
            })),
        })
    );
```

Here

```zig
thread 401259 panic: integer overflow
/home/usr/projects/zgt/src/containers.zig:65:126: 0x21be00 in .zgt.containers.ColumnLayout (zscale)
                .height = if (widget.container_expanded) childHeight else (@intCast(u32, peer.getSize(peer.userdata).height) - @floatToInt(u32, childY)),
                                                                                                                             ^
/home/usr/projects/zgt/src/containers.zig:330:24: 0x21f728 in .zgt.containers.Container_Impl.relayout (zscale)
            self.layout(callbacks, self.childrens.items);
                       ^
/home/usr/projects/zgt/src/containers.zig:283:30: 0x23be34 in .zgt.containers.Container_Impl.show (zscale)
            try self.relayout();
                             ^
/home/usr/projects/zgt/src/internal.zig:78:31: 0x216679 in .zgt.internal.Widgeting(.zgt.containers.Container_Impl).showWidget (zscale)
            try component.show();
                              ^
/home/usr/projects/zgt/src/widget.zig:48:30: 0x21c6a1 in .zgt.widget.Widget.show (zscale)
        try self.class.showFn(self);
                             ^
/home/usr/projects/zgt/src/tabs.zig:26:36: 0x23cd42 in .zgt.tabs.Tabs_Impl.show (zscale)
                try tab.widget.show();
                                   ^
/home/usr/projects/zgt/src/internal.zig:78:31: 0x2169a9 in .zgt.internal.Widgeting(.zgt.tabs.Tabs_Impl).showWidget (zscale)
            try component.show();
                              ^
/home/usr/projects/zgt/src/widget.zig:48:30: 0x21c6a1 in .zgt.widget.Widget.show (zscale)
        try self.class.showFn(self);
                             ^
/home/usr/projects/zgt/src/window.zig:46:31: 0x218ab5 in main (zscale)
        try self._child.?.show();
                              ^
/home/usr/projects/zig/build/lib/zig/std/start.zig:581:37: 0x220207 in std.start.callMain (zscale)
            const result = root.main() catch |err| {
                                    ^
/home/usr/projects/zig/build/lib/zig/std/start.zig:515:12: 0x2195b7 in std.start.callMainWithArgs (zscale)
    return @call(.{ .modifier = .always_inline }, callMain, .{});
           ^
/home/usr/projects/zig/build/lib/zig/std/start.zig:480:12: 0x219362 in std.start.main (zscale)
    return @call(.{ .modifier = .always_inline }, callMainWithArgs, .{ @intCast(usize, c_argc), c_argv, envp });
           ^
???:?:?: 0x7faf25cce082 in ??? (???)
```

I added some prints and the height is 1 and childY is 6. 

```
warning: .zgt.data.Size{ .width = 1, .height = 1 } childY=0.0e+00
warning: .zgt.data.Size{ .width = 1, .height = 1 } childY=6.0e+00
warning: .zgt.data.Size{ .width = 718, .height = 281 } childY=0.0e+00
warning: .zgt.data.Size{ .width = 718, .height = 281 } childY=4.5e+01
warning: .zgt.data.Size{ .width = 718, .height = 281 } childY=0.0e+00

```

I'm not sure if it has something to do with window animations but the PR is a workaround...


