### PR TITLE
fix: updated zig FOD

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
           
           src = pkgs.fetchurl {
             url = "https://ziglang.org/download/${version}/zig-x86_64-linux-${version}.tar.xz";
-            sha256 = "sha256-e+ar3r+pcMYTjRZbNI0EZOhPFvUx5xyyDA4FL64djI0=";
+            sha256 = "sha256-JK7uyK8Ww4GTSmzX2VyAeoyyz335+kDTWaqIQZXEcWw=";
           };
           
           installPhase = ''


### PR DESCRIPTION
For whatever reason, the zig tarball URL we were using had changed, compromising the hash integrity. My best guess as to why Zig Software Foundation did this is they must've rolled some security update and saw it fit to break their permalinks... or they were never permalinks to begin with...

I however wonder about the comment in flake.nix#L22 as it isn't making much sense to me. It claims that capy requires 2024.11.0-mach, however 0.14.1 is specified... 0.14.1 released on 2025-05-21, not in 2024... futhermore, even one version behind, 0.14.0, was released on 2025-03-05, even *it* wasn't in 2024. I have no clue what is up with this requirement, but for now with this fix capy seems to work just fine. I built a few examples just to check.